### PR TITLE
Add policyFileDir parameter to HDFS operators

### DIFF
--- a/com.ibm.streamsx.hdfs/com.ibm.streamsx.hdfs/HDFS2DirectoryScan/HDFS2DirectoryScan.xml
+++ b/com.ibm.streamsx.hdfs/com.ibm.streamsx.hdfs/HDFS2DirectoryScan/HDFS2DirectoryScan.xml
@@ -235,6 +235,16 @@ When connecting to HDFS instances deployed on Bluemix, the credentials are provi
         <cardinality>1</cardinality>
       </parameter>
       <parameter>
+        <name>policyFilePath</name>
+        <description>
+This optional parameter is relevant when connecting to BigInsights on Bluemix. It specifies the path to the directory that contains the Java Cryptography Extension policy files (US_export_policy.jar and local_policy.jar). The policy files enable the Java operators to use encryption with key sizes beyond the limits specified by the JDK. See the section on "Policy file configuration" in the main page of this toolkit's documentation for information on how to configure the policy files.
+If this parameter is omitted the JVM default policy files will be used. When specified, this parameter takes precedence over the JVM default policy files.
+**Note:** This parameter changes a JVM property. If you set this property, be sure it is set to the same value in all HDFS operators that are in the same PE. The location of the policy file directory can be absolute path on the file system or a path that is relative to the application directory.</description>
+        <optional>true</optional>
+        <type>rstring</type>
+        <cardinality>1</cardinality>
+      </parameter>
+      <parameter>
         <name>configPath</name>
         <description>This optional parameter specifies the absolute path to the directory that contains the HDFS configuration files. If this parameter is not specified, by default the operator looks for the `core-site.xml` file in the following locations:
  * `$HADOOP_HOME/../hadoop-conf`

--- a/com.ibm.streamsx.hdfs/com.ibm.streamsx.hdfs/HDFS2FileSink/HDFS2FileSink.xml
+++ b/com.ibm.streamsx.hdfs/com.ibm.streamsx.hdfs/HDFS2FileSink/HDFS2FileSink.xml
@@ -311,6 +311,16 @@ When specified, this parameter takes precedence over the `$HADOOP_HOME` environm
         <type>rstring</type>
         <cardinality>1</cardinality>
       </parameter>
+      <parameter>
+        <name>policyFilePath</name>
+        <description>
+This optional parameter is relevant when connecting to BigInsights on Bluemix. It specifies the path to the directory that contains the Java Cryptography Extension policy files (US_export_policy.jar and local_policy.jar). The policy files enable the Java operators to use encryption with key sizes beyond the limits specified by the JDK. See the section on "Policy file configuration" in the main page of this toolkit's documentation for information on how to configure the policy files.
+If this parameter is omitted the JVM default policy files will be used. When specified, this parameter takes precedence over the JVM default policy files.
+**Note:** This parameter changes a JVM property. If you set this property, be sure it is set to the same value in all HDFS operators that are in the same PE. The location of the policy file directory can be absolute path on the file system or a path that is relative to the application directory.</description>
+        <optional>true</optional>
+        <type>rstring</type>
+        <cardinality>1</cardinality>
+      </parameter>
     </parameters>
     <inputPorts>
       <inputPortSet>

--- a/com.ibm.streamsx.hdfs/com.ibm.streamsx.hdfs/HDFS2FileSource/HDFS2FileSource.xml
+++ b/com.ibm.streamsx.hdfs/com.ibm.streamsx.hdfs/HDFS2FileSource/HDFS2FileSource.xml
@@ -277,6 +277,16 @@ When specified, this parameter takes precedence over the `$HADOOP_HOME` environm
         <type>rstring</type>
         <cardinality>1</cardinality>
       </parameter>   
+      <parameter>
+        <name>policyFilePath</name>
+        <description>
+This optional parameter is relevant when connecting to BigInsights on Bluemix. It specifies the path to the directory that contains the Java Cryptography Extension policy files (US_export_policy.jar and local_policy.jar). The policy files enable the Java operators to use encryption with key sizes beyond the limits specified by the JDK. See the section on "Policy file configuration" in the main page of this toolkit's documentation for information on how to configure the policy files.
+If this parameter is omitted the JVM default policy files will be used. When specified, this parameter takes precedence over the JVM default policy files.
+**Note:** This parameter changes a JVM property. If you set this property, be sure it is set to the same value in all HDFS operators that are in the same PE. The location of the policy file directory can be absolute path on the file system or a path that is relative to the application directory.</description>
+        <optional>true</optional>
+        <type>rstring</type>
+        <cardinality>1</cardinality>
+      </parameter>
     </parameters>
     <inputPorts>
       <inputPortSet>

--- a/com.ibm.streamsx.hdfs/impl/java/src/com/ibm/streamsx/hdfs/AbstractHdfsOperator.java
+++ b/com.ibm.streamsx.hdfs/impl/java/src/com/ibm/streamsx/hdfs/AbstractHdfsOperator.java
@@ -52,14 +52,24 @@ public abstract class AbstractHdfsOperator extends AbstractOperator {
 	private String fKeyStorePath;
 	private String fKeyStorePassword;
 	private String fLibPath; //Used to allow the user to override the hadoop home environment variable
+	private String fPolicyFilePath;
 
 	@Override
 	public synchronized void initialize(OperatorContext context)
 			throws Exception {
 		super.initialize(context);
 		setupClassPaths(context);
+		processPolicyFilePath();
 		fHdfsClient = createHdfsClient();
 		fHdfsClient.connect(getHdfsUri(), getHdfsUser(), getAbsolutePath(getConfigPath()));
+	}
+
+	private void processPolicyFilePath() {
+		String policyFilePath = getAbsolutePath(getPolicyFilePath());
+		if (policyFilePath != null) {
+			TRACE.log(TraceLevel.INFO, "Policy file path: " + policyFilePath);
+			System.setProperty("com.ibm.security.jurisdictionPolicyDir", policyFilePath);
+		}
 	}
 
 	private  void setupClassPaths(OperatorContext context) {
@@ -246,6 +256,11 @@ public abstract class AbstractHdfsOperator extends AbstractOperator {
 	public String getKeyStorePassword() {
 		return fKeyStorePassword;
 	}
+
+	public String getPolicyFilePath() {
+		return fPolicyFilePath;
+	}
+
 	@Parameter(optional=true)	
 	public void setHdfsPassword(String pass) {
 		fHdfsPassword = pass;
@@ -263,5 +278,10 @@ public abstract class AbstractHdfsOperator extends AbstractOperator {
 	@Parameter(optional=true) 
 	public void setLibPath(String libPath) {
 		fLibPath = libPath;
+	}
+
+	@Parameter(optional=true)
+	public void setPolicyFilePath(String policyFilePath) {
+		fPolicyFilePath = policyFilePath;
 	}
 }

--- a/com.ibm.streamsx.hdfs/info.xml
+++ b/com.ibm.streamsx.hdfs/info.xml
@@ -77,10 +77,25 @@ If the  **HADOOP_HOME** environment variable is set, attempts to connect to a HD
 		      hdfsPassword: "bi_password";
 		      hdfsUser:"bi_user";
 		   }
-4. To read and write to HDFS, specify a uniform resource identifier (URI) to connect to HDFS using the **hdfsUri** operator parameter.
-5. Build your application.  You can use the **sc** command or Streams Studio.  
-6. Start the InfoSphere Streams instance. 
-7. Run the application. You can submit the application as a job by using the **streamtool submitjob** command or by using Streams Studio. You can also submit the application to run in the cloud using the Streaming Analytics service on Bluemix.
+5. Policy file configuration
+
+   BigInsights on Bluemix uses encryption keys larger than what is supported by the default IBM JDK. To connect to BigInsights, complete the following steps.
+   * Download and extract the [https://www-01.ibm.com/marketing/iwm/iwm/web/preLogin.do?source=jcesdk|Unrestricted SDK JCE policy files]. You have two options when deciding where to put the US_export_policy.jar and local_policy.jar:
+     * If you have access to the Streams cluster file system, you can replace the default policy files in &lt;JAVA_HOME>/jre/lib/security/ with the ones you downloaded.
+     * If you cannot access the file system, put them somewhere in the application's etc directory - for example, &lt;application_directory>/etc/policyfiles/ .
+   * If you placed the policy files in your application's etc directory, set the **policyFilePath** parameter in your application to the relative path to the directory containing your policy files. For example:
+		 () as HDFS2FileSink_2 = HDFS2FileSink(In) {
+		     param
+		      file: "output_file.txt";
+		      hdfsUri: "webhdfs://server_host_name:8443";
+		      hdfsPassword: "bi_password";
+		      hdfsUser: "bi_user";
+		      policyFilePath: "etc/policyfiles/"
+		 }
+6. To read and write to HDFS, specify a uniform resource identifier (URI) to connect to HDFS using the **hdfsUri** operator parameter.
+7. Build your application.  You can use the **sc** command or Streams Studio.  
+8. Start the InfoSphere Streams instance. 
+9. Run the application. You can submit the application as a job by using the **streamtool submitjob** command or by using Streams Studio. You can also submit the application to run in the cloud using the Streaming Analytics service on Bluemix.
 
 + Using the toolkit to connect to HDFS outside of Bluemix
 

--- a/samples/HDFSBluemixDemo/etc/policyfiles/.gitignore
+++ b/samples/HDFSBluemixDemo/etc/policyfiles/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/samples/HDFSBluemixDemo/hdfsexample/TestDirScan.spl
+++ b/samples/HDFSBluemixDemo/hdfsexample/TestDirScan.spl
@@ -20,6 +20,8 @@ use com.ibm.streamsx.hdfs::HDFS2FileSource ;
  *
  * 
  * Setup:
+ * Download the Unrestricted SDK JCE policy files from https://www-01.ibm.com/marketing/iwm/iwm/web/preLogin.do?source=jcesdk
+ * Place downloaded local_policy.jar and US_export_policy.jar in <application directory>/etc/policyfiles/
  * You will need to create new directory for the HDFS2DirectoryScan operator to scan.
  * if you have SSH access to the system where Hadoop is installed:
  * 1. Create a new directory in HDFS by running this command at the command line, 
@@ -51,6 +53,7 @@ public composite TestDirScan
 				hdfsUri : $hdfsUri ;
 				hdfsUser:$hdfsUser;
 				hdfsPassword: $hdfsPassword;
+				policyFilePath: "etc/policyfiles";
 		}
 
 		// use the file name from directory scan to read the file
@@ -60,6 +63,7 @@ public composite TestDirScan
 				hdfsUri : $hdfsUri ;
 				hdfsUser:$hdfsUser;
 				hdfsPassword: $hdfsPassword;
+				policyFilePath: "etc/policyfiles";
 		} 
 
 		//print out the names of each file found in the directory

--- a/samples/HDFSBluemixDemo/hdfsexample/TestRead.spl
+++ b/samples/HDFSBluemixDemo/hdfsexample/TestRead.spl
@@ -8,6 +8,8 @@ use com.ibm.streamsx.hdfs::*;
 /**
  * This application shows how to connect to a Hadoop instance running on Bluemix.
  * Specify the name of a file to read from  HDFS as a submission time parameter.
+ * Download the Unrestricted SDK JCE policy files from https://www-01.ibm.com/marketing/iwm/iwm/web/preLogin.do?source=jcesdk
+ * Place downloaded local_policy.jar and US_export_policy.jar in <application directory>/etc/policyfiles/
  * Additional required parameters are the uri of the HDFS server and the username and password information for authentication.
  * Tip: Run the TestWrite composite first and specify the name of the file created by that application as input in this one. 
  * See the toolkit's documenatio for compile and run instructions.
@@ -31,6 +33,7 @@ graph
 			hdfsPassword: $hdfsPassword;
 			hdfsUser:$hdfsUser;
 			file: $file;
+			policyFilePath: "etc/policyfiles";
   	}
   
 	 () as PrintContents = Custom(FromHDFS) {

--- a/samples/HDFSBluemixDemo/hdfsexample/TestWrite.spl
+++ b/samples/HDFSBluemixDemo/hdfsexample/TestWrite.spl
@@ -9,6 +9,8 @@ use com.ibm.streamsx.hdfs::*;
 /**
  * This application shows how to connect to a Hadoop instance running on Bluemix.
  * Specify the name of a file to write to  HDFS as a submission time parameter.
+ * Download the Unrestricted SDK JCE policy files from https://www-01.ibm.com/marketing/iwm/iwm/web/preLogin.do?source=jcesdk
+ * Place downloaded local_policy.jar and US_export_policy.jar in <application directory>/etc/policyfiles/
  * Additional required parameters are the uri of the HDFS server and the username and password information for authentication.
  * Tip: Run this composite, then run the TestRead composite  and specify the same file name to read that file from HDFS and verify the write worked correctly. 
  * See the toolkit's documentation for compile and run instructions.
@@ -40,6 +42,7 @@ graph
 		hdfsUri : $hdfsUri ;
 		hdfsUser:$hdfsUser;
 		hdfsPassword: $hdfsPassword;
+		policyFilePath: "etc/policyfiles";
  	
  }
  () as Log = Custom(Sink) {


### PR DESCRIPTION
@natashadsilva
Please review. I'll make a pull request to the IBMStreams repo once you approve the changes.

This change enables Streams to connect to BigInsights which uses unlimited jurisdiction policy files.

Work item: [RTC #33115](https://spirit126.watson.ibm.com/jazz/web/projects/Streaming%20Analytics%20%28Bluemix%29#action=com.ibm.team.workitem.viewWorkItem&id=33115)
